### PR TITLE
Remove newlines from the x() function definition.

### DIFF
--- a/servers/window_server/src/CursorManager.h
+++ b/servers/window_server/src/CursorManager.h
@@ -40,10 +40,7 @@ public:
     inline LG::Point<int> draw_position() { return { m_mouse_x - 6, m_mouse_y - 6 }; }
 #endif
 
-    inline int x() const
-    {
-        return m_mouse_x;
-    }
+    inline int x() const { return m_mouse_x; }
     inline int y() const { return m_mouse_y; }
 
     template <Params param>


### PR DESCRIPTION
The body is small and y() has no newlines.